### PR TITLE
1.0.2 - Introduce quick actions 'new' and 'open'

### DIFF
--- a/Adr/Adr.csproj
+++ b/Adr/Adr.csproj
@@ -10,12 +10,12 @@
 
   <PropertyGroup>
     <PackageId>ADR-Cli</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>digitaldias</Authors>
     <Company>digitaldias</Company>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Add ability to supersede an existing ADR</PackageReleaseNotes>
+    <PackageReleaseNotes>Introduce the first subcommand 'new'</PackageReleaseNotes>
     <PackageTags>adr, architecture, decisions, records, cli, commandline, command-line</PackageTags>
     <Description>A command-line tool for working with Architecture Decisions Records</Description>
     <RepositoryUrl>https://github.com/digitaldias/AdrTool</RepositoryUrl>

--- a/Adr/Adr.csproj
+++ b/Adr/Adr.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
     <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Adr/AdrTool.cs
+++ b/Adr/AdrTool.cs
@@ -99,11 +99,11 @@ public sealed class AdrTool
 
         var tableMenu = new[]
         {
-            new LiveKeyAction<AdrEntry>('a', "Add new", _ => AddNewAdrEntry()),
-            new LiveKeyAction<AdrEntry>('r', "Rename selected", entry => Rename(entry)),
-            new LiveKeyAction<AdrEntry>('i', "Recreate index from folder", _ => IndexManipulator.RecreateIndex(_adrFolder)),
+            new LiveKeyAction<AdrEntry>('a', "Add", _ => AddNewAdrEntry()),
+            new LiveKeyAction<AdrEntry>('r', "Rename", entry => Rename(entry)),
+            new LiveKeyAction<AdrEntry>('s', "Supersede", e => Supersede(e)),
             new LiveKeyAction<AdrEntry>('o', "Open ADR folder in VS Code", _ => VSCode.OpenFolder(_adrFolder)),
-            new LiveKeyAction<AdrEntry>('s', "Supersede with new ADR entry", e => Supersede(e))
+            new LiveKeyAction<AdrEntry>('i', "Recreate index from folder content", _ => IndexManipulator.RecreateIndex(_adrFolder)),
         };
 
         if (_adrEntries.Any())

--- a/Adr/Commands/NewCommand.cs
+++ b/Adr/Commands/NewCommand.cs
@@ -1,0 +1,30 @@
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Adr.Commands;
+public static class NewCommand
+{
+    public static void Configure(CommandLineApplication app)
+        => app.Command("new", newCmd =>
+        {
+            newCmd.Description = "Quickly add a new ADR";
+
+            var titleArgument = newCmd.Argument("title", "The title of the new ADR", false);
+            var pathArgument = newCmd.Argument("path", "Optional. Absolute or relative path to project. Current dir when omitted", false);
+
+            newCmd.HelpOption();
+
+            newCmd.OnExecute(() =>
+            {
+                if (string.IsNullOrEmpty(titleArgument.Value))
+                {
+                    Cout.Warn("You must specify a title for the new command");
+                    return 1;
+                }
+
+                var path = pathArgument.HasValue ? pathArgument.Value : Environment.CurrentDirectory;
+                var tool = new AdrTool(path);
+                tool.Run("new", titleArgument.Value);
+                return 0;
+            });
+        });
+}

--- a/Adr/Commands/OpenCommand.cs
+++ b/Adr/Commands/OpenCommand.cs
@@ -1,0 +1,23 @@
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Adr.Commands;
+
+public static class OpenCommand
+{
+    public static void Configure(CommandLineApplication app)
+        => app.Command("open", newCmd =>
+        {
+            newCmd.Description = "Open your ADR folder in VS Code";
+            var pathArgument = newCmd.Argument("path", "The absolute or relative path (optional, defaults to current directory)");
+
+            newCmd.HelpOption();
+
+            newCmd.OnExecute(() =>
+            {
+                var path = pathArgument.HasValue ? pathArgument.Value : Environment.CurrentDirectory;
+                var tool = new AdrTool(path);
+                tool.Run("open");
+                return 0;
+            });
+        });
+}

--- a/Adr/Properties/launchSettings.json
+++ b/Adr/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Adr": {
       "commandName": "Project",
-      "commandLineArgs": "."
+      "commandLineArgs": ""
     }
   }
 }

--- a/Adr/VsCoding/VSCode.cs
+++ b/Adr/VsCoding/VSCode.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace Adr.VsCoding;
 
@@ -31,6 +31,7 @@ public static class VSCode
 
     public static void OpenFile(string filePath)
     {
+        Cout.Success("Opening '{FilePath}' in VS Code", filePath);
         var startInfo = new ProcessStartInfo("code", filePath)
         {
             UseShellExecute = true,
@@ -42,6 +43,7 @@ public static class VSCode
 
     public static void OpenFolder(string docsFolder)
     {
+        Cout.Info("Opening folder '[yellow]{_adrFolder}[/]' in VS Code", docsFolder);
         var startInfo = new ProcessStartInfo("code", docsFolder)
         {
             UseShellExecute = true,


### PR DESCRIPTION
- Clean up CommandLineArgs in launchSettings
- Add feedback text when opening files and folders in VS Code
- Rearrange and rename the table menu
- Add McMaster.Extensions.CommandLineUtils to the project
- Introduce the quick-action `new` for immediately appending a new ADR
- Introduce QuickAction `Open` for immediately opening the ADR folder in VS Code
- Add and implement command and title parameters to AdrTool.Run()
- Start working on v1.0.2, which introduces the 'new' command